### PR TITLE
Added option to skip certificates in certdata

### DIFF
--- a/convert_mozilla_certdata.go
+++ b/convert_mozilla_certdata.go
@@ -51,8 +51,8 @@ type Attribute struct {
 	value    []byte
 }
 
-// ignoreList contains the names of certificates to ignore
-// the value can be an optional comment
+// ignoreList maps from CKA_LABEL values (from the upstream roots file) to an optional comment
+// which is displayed when skipping matching certificates.
 var ignoreList map[string]string
 
 var includedUntrustedFlag = flag.Bool("include-untrusted", false, "If set, untrusted certificates will also be included in the output")

--- a/convert_mozilla_certdata.go
+++ b/convert_mozilla_certdata.go
@@ -206,7 +206,11 @@ func outputTrustedCerts(out *os.File, objects []*Object) {
 
 		label := string(cert.attrs["CKA_LABEL"].value)
 		if comment, present := ignoreList[strings.Trim(label, "\"")]; present {
-			log.Printf("Skipping explicitly ignored certificate: %s: %s", label, comment)
+			var sep string
+			if len(comment) > 0 {
+				sep = ": "
+			}
+			log.Printf("Skipping explicitly ignored certificate: %s%s%s", label, sep, comment)
 			continue
 		}
 

--- a/convert_mozilla_certdata.go
+++ b/convert_mozilla_certdata.go
@@ -102,9 +102,9 @@ func parseIgnoreList(ignoreListFile io.Reader) {
 	var lineNo int
 
 	for line, eof := getLine(in, &lineNo); !eof; line, eof = getLine(in, &lineNo) {
-		if splitted := strings.SplitN(line, "#", 2); len(splitted) == 2 {
+		if split := strings.SplitN(line, "#", 2); len(split) == 2 {
 			// this line has an additional comment
-			ignoreList[strings.TrimSpace(splitted[0])] = strings.TrimSpace(splitted[1])
+			ignoreList[strings.TrimSpace(split[0])] = strings.TrimSpace(split[1])
 		} else {
 			ignoreList[line] = ""
 		}

--- a/convert_mozilla_certdata.go
+++ b/convert_mozilla_certdata.go
@@ -221,7 +221,7 @@ func outputTrustedCerts(out *os.File, objects []*Object) {
 			log.Fatalf("Unknown trust value '%s' found for trust record starting on line %d", trustType, trust.startingLine)
 		}
 
-		if (!trusted && !*includedUntrustedFlag) {
+		if !trusted && !*includedUntrustedFlag {
 			continue
 		}
 


### PR DESCRIPTION
User can now use the "-ignore-list=ignore.txt" option to specify a list of certificates to skip during extraction.

The value of the CKA_LABEL attribute is used to perform the check.

Each line in the ignore list can contain an optional comment at the end (separated by '#') that will be displayed when a matching certificate is found.
